### PR TITLE
Glorious Fullscreen! 

### DIFF
--- a/assets/js/ui/board.js
+++ b/assets/js/ui/board.js
@@ -105,6 +105,19 @@
       }
       */
 
+      $scope.goFullScreen = function() {
+        var element = document.documentElement;
+	if(element.requestFullscreen) {
+          element.requestFullscreen();
+        } else if(element.mozRequestFullScreen) {
+          element.mozRequestFullScreen();
+        } else if(element.webkitRequestFullscreen) {
+          element.webkitRequestFullscreen();
+        } else if(element.msRequestFullscreen) {
+          element.msRequestFullscreen();
+        }
+      }
+
       $scope.timerStart = function(minutes) {
         $scope.showTimerForm = false;
         api.timerStart(board.id(), minutes * 60);

--- a/assets/templates/board.html
+++ b/assets/templates/board.html
@@ -46,6 +46,9 @@
                     {{board.votesRemaining()}} vote{{board.votesRemaining() === 1 ? '' : 's'}}
                     Left
                 </li>
+		<li>
+			<a href="#" data-ng-click="goFullScreen(document.documentElement)">X</a>
+		</li>
                 <li>
                     <a href="#" data-ng-click="showTimerForm = !showTimerForm">
                         <svg class="icon-left" width="22px" height="21px" viewBox="0 0 22 21" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">

--- a/assets/templates/board.html
+++ b/assets/templates/board.html
@@ -33,6 +33,9 @@
         <li>
             <ul class="x-list">
                 <li>
+                    <a href="#" data-ng-click="goFullScreen()">Full Screen</a>
+                </li>
+                <li>
                     <a href="#" data-ng-click="switchTab('settings')" data-ng-class="{active:currentTab === 'settings'}">
                         <svg class="icon-left" width="21px" height="21px" viewBox="0 0 21 21" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
                             <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
@@ -46,9 +49,6 @@
                     {{board.votesRemaining()}} vote{{board.votesRemaining() === 1 ? '' : 's'}}
                     Left
                 </li>
-		<li>
-			<a href="#" data-ng-click="goFullScreen(document.documentElement)">X</a>
-		</li>
                 <li>
                     <a href="#" data-ng-click="showTimerForm = !showTimerForm">
                         <svg class="icon-left" width="22px" height="21px" viewBox="0 0 22 21" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">


### PR DESCRIPTION
Adding some fullscreen functions to the board view so meetings on projectors with LucidBoard can be even more glorious. Still needs an equally glorious icon to accompany it. 